### PR TITLE
support python 3.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,7 @@ native Vim callables.  Both arguments and return values are casted so it should
 be transparent::
 
     python << endpython
+    #py3 << endpython
     from vim_bridge import bridged
 
     @bridged
@@ -54,6 +55,7 @@ More examples
 Passing in a list::
 
     python << endpython
+    #py3 << endpython
     from vim_bridge import bridged
 
     @bridged
@@ -69,6 +71,7 @@ Passing in a list::
 Catching exceptions::
 
     python << endpython
+    #py3 << endpython
     from vim_bridge import bridged
 
     @bridged
@@ -94,6 +97,7 @@ Using Python stdlib functions to do work that would be more difficult using
 pure Vim scripting::
 
     python << END
+    #py3 << END
     import os.path
     from vim_bridge import bridged
 
@@ -111,6 +115,7 @@ from inside Vim, it does not matter.  In this example, NormalizePath is called
 from both Python and Vim::
 
     python << END
+    #py3 << END
     import os.path
     from vim_bridge import bridged
 
@@ -137,6 +142,7 @@ the Vim context as a ``<SID>``-prefixed function (i.e. a "private" function
 that cannot be called from outside the script)::
 
     python << eop
+    #py3 << eop
     import os
     import vim
     from vim_bridge import bridged

--- a/examples/example1.vim
+++ b/examples/example1.vim
@@ -1,4 +1,5 @@
 python << endpython
+#py3 << endpython
 from vim_bridge import bridged
 
 @bridged

--- a/examples/example2.vim
+++ b/examples/example2.vim
@@ -1,4 +1,5 @@
 python << endpython
+#py3 << endpython
 from vim_bridge import bridged
 
 @bridged

--- a/examples/example3.vim
+++ b/examples/example3.vim
@@ -1,4 +1,5 @@
 python << endpython
+#py3 << endpython
 from vim_bridge import bridged
 
 @bridged

--- a/examples/example4.vim
+++ b/examples/example4.vim
@@ -1,4 +1,5 @@
 python << END
+#py3 << END
 import os.path
 from vim_bridge import bridged
 

--- a/examples/example5.vim
+++ b/examples/example5.vim
@@ -1,4 +1,5 @@
 python << END
+#py3 << END
 import os.path
 from vim_bridge import bridged
 

--- a/examples/example6.vim
+++ b/examples/example6.vim
@@ -1,4 +1,5 @@
 python << eop
+#py3 << eop
 import os
 import vim
 from vim_bridge import bridged

--- a/examples/example7.vim
+++ b/examples/example7.vim
@@ -1,4 +1,5 @@
 python << END
+#py3 << END
 import os.path
 from vim_bridge import bridged
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "Programming Language :: Python :: 2.5",
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.5",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: POSIX",

--- a/tests/test_vim_bridge.py
+++ b/tests/test_vim_bridge.py
@@ -1,8 +1,12 @@
+# vim: fileencoding=utf-8
+
+## py.test tests
+
 import unittest
 
 # Fake the system path to direct "import vim" calls to our mock module
 import sys
-sys.path = ['tests/mocks'] + sys.path
+sys.path = ['.','tests/mocks'] + sys.path
 
 # Stub out the random function
 import vim_bridge
@@ -69,13 +73,13 @@ class TestBridgedDecorator(unittest.TestCase):
         from vim_bridge.registry import func_register
         import vim
 
-        self.assertFalse(func_register.has_key('foo'))
+        self.assertFalse('foo' in func_register)
         self.assertFalse(vim.command.called)
 
         @bridged
         def foo(x,y): pass
 
-        self.assertTrue(func_register.has_key('foo'))
+        self.assertTrue('foo' in func_register)
         self.assertTrue(vim.command.called)
         self.assertCodeEquals(vim.command.call_args[0][0], \
            """

--- a/tests/test_vim_bridge.py
+++ b/tests/test_vim_bridge.py
@@ -6,7 +6,7 @@ import unittest
 
 # Fake the system path to direct "import vim" calls to our mock module
 import sys
-sys.path = ['.','tests/mocks'] + sys.path
+sys.path = ['.','./tests/mocks'] + sys.path
 
 # Stub out the random function
 import vim_bridge
@@ -83,6 +83,24 @@ class TestBridgedDecorator(unittest.TestCase):
         self.assertTrue(vim.command.called)
         self.assertCodeEquals(vim.command.call_args[0][0], \
            """
+           if has('python3')
+           fun! Foo(x, y)
+           py3 << endp
+           __vim_brdg_3_x = vim.eval("a:x")
+           __vim_brdg_3_y = vim.eval("a:y")
+
+           from vim_bridge.registry import func_register as fr
+           from vim_bridge import _cast_to_vimsafe_result as c2v
+
+           __vim_brdg_3_result = c2v(fr["foo"](__vim_brdg_3_x, __vim_brdg_3_y))
+           vim.command("return %s" % repr(__vim_brdg_3_result))
+
+           del __vim_brdg_3_x
+           del __vim_brdg_3_y
+           del __vim_brdg_3_result
+           endp
+           endf
+           else
            fun! Foo(x, y)
            python << endp
            __vim_brdg_3_x = vim.eval("a:x")
@@ -99,5 +117,6 @@ class TestBridgedDecorator(unittest.TestCase):
            del __vim_brdg_3_result
            endp
            endf
+           endif
            """)
 

--- a/vim_bridge/__init__.py
+++ b/vim_bridge/__init__.py
@@ -62,22 +62,25 @@ def bridged(fin):
 
     prefix = '__vim_brdg_%d_' % _rand()
 
-    lines = ['fun! %s%s(%s)' % (private, vimname, ", ".join(func_args))]
-    lines.append('python << endp')
-    for arg in func_args:
-        lines.append('%s%s = vim.eval("a:%s")' % (prefix, arg, arg))
-    lines.append('from vim_bridge.registry import func_register as fr')
-    lines.append('from vim_bridge import _cast_to_vimsafe_result as c2v')
-    lines.append('%sresult = c2v(fr["%s"](%s))' % (prefix, func_name, \
-            ", ".join([prefix + s for s in func_args])))
-    lines.append('vim.command("return %%s" %% repr(%sresult))' % prefix)
-    for arg in func_args:
-        #lines.append('try:')
-        lines.append('del %s%s' % (prefix, arg))
-        #lines.append('except NameError: pass')
-    lines.append('del %sresult' % prefix)
-    lines.append('endp')
-    lines.append('endf')
+    def _vim_fun(pyver):
+        lines = ['fun! %s%s(%s)' % (private, vimname, ", ".join(func_args))]
+        lines.append(pyver+' << endp')
+        for arg in func_args:
+            lines.append('%s%s = vim.eval("a:%s")' % (prefix, arg, arg))
+        lines.append('from vim_bridge.registry import func_register as fr')
+        lines.append('from vim_bridge import _cast_to_vimsafe_result as c2v')
+        lines.append('%sresult = c2v(fr["%s"](%s))' % (prefix, func_name, \
+                ", ".join([prefix + s for s in func_args])))
+        lines.append('vim.command("return %%s" %% repr(%sresult))' % prefix)
+        for arg in func_args:
+            #lines.append('try:')
+            lines.append('del %s%s' % (prefix, arg))
+            #lines.append('except NameError: pass')
+        lines.append('del %sresult' % prefix)
+        lines.append('endp')
+        lines.append('endf')
+        return lines
+    lines = ["if has('python3')"] + _vim_fun('py3') + ['else'] + _vim_fun('python') + ['endif']
     vim.command("\n".join(lines))
 
     return fin

--- a/vim_bridge/__init__.py
+++ b/vim_bridge/__init__.py
@@ -2,7 +2,7 @@ from vim_bridge.registry import func_register
 
 __all__ = ['bridged', '_cast_to_vimsafe_result', '__version__']
 
-VERSION = (0, 5)
+VERSION = (0, 6)
 __version__ = ".".join(map(str, VERSION[0:2]))
 
 
@@ -28,7 +28,10 @@ def _convert_function_name(fname):
 
 
 def _get_arguments(func):
-    return func.func_code.co_varnames[:func.func_code.co_argcount]
+    try:
+        return func.func_code.co_varnames[:func.func_code.co_argcount]
+    except AttributeError:
+        return func.__code__.co_varnames[:func.__code__.co_argcount]
 
 
 def _cast_to_vimsafe_result(value):
@@ -46,11 +49,15 @@ def _cast_to_vimsafe_result(value):
 
 def bridged(fin):
     import vim
-    func_register[fin.func_name] = fin
+    try:
+        func_name = fin.func_name
+    except:
+        func_name = fin.__name__
+    func_register[func_name] = fin
 
     func_args = _get_arguments(fin)
 
-    private, vimname = _convert_function_name(fin.func_name)
+    private, vimname = _convert_function_name(func_name)
     private = private and "s:" or ""
 
     prefix = '__vim_brdg_%d_' % _rand()
@@ -61,7 +68,7 @@ def bridged(fin):
         lines.append('%s%s = vim.eval("a:%s")' % (prefix, arg, arg))
     lines.append('from vim_bridge.registry import func_register as fr')
     lines.append('from vim_bridge import _cast_to_vimsafe_result as c2v')
-    lines.append('%sresult = c2v(fr["%s"](%s))' % (prefix, fin.func_name, \
+    lines.append('%sresult = c2v(fr["%s"](%s))' % (prefix, func_name, \
             ", ".join([prefix + s for s in func_args])))
     lines.append('vim.command("return %%s" %% repr(%sresult))' % prefix)
     for arg in func_args:


### PR DESCRIPTION
Hello nvie. I've ported this little python package of yours to python 3.5. It still should work with Python 2.7 as well, but I haven't tried. It would be great if you could take over these changes and also update PyPI. The reason, why I did this port, was that I wanted to use your vim-rst-table in Python3 enabled vim.